### PR TITLE
Corrections v01 - QOL and Final Validations

### DIFF
--- a/registers/models/bill.py
+++ b/registers/models/bill.py
@@ -241,6 +241,14 @@ class Bill(models.Model):
                 if rec.external_operation_id.operation_status == '0':
                     raise ValidationError(_("O caixa está fechado."))
 
+    @api.constrains('external_contract_id')
+    def _check_patrimony_contract_link(self):
+        """Checks if the patrimony listed exists in the contract listed"""
+        for rec in self:
+            if rec.external_contract_id and rec.external_patrimony_id:
+                if rec.external_patrimony_id not in rec.external_contract_id.patrimony_ids:
+                    raise ValidationError(_("O patrimônio listado não está no contrato listado."))
+
     _sql_constraints = [
         ('id_bill_installment_unique', 'UNIQUE(id_bill, installment)',
         'Já existe uma \'Conta a Pagar\' com essa \'Parcela\' registrada ou'

--- a/registers/models/client.py
+++ b/registers/models/client.py
@@ -1,4 +1,4 @@
-# pylint: disable=line-too-long, super-with-arguments, no-else-raise
+# pylint: disable=line-too-long, super-with-arguments, no-else-raise, too-many-instance-attributes
 """This are the client template and it's associated functions"""
 import re
 from odoo import models, fields, api, _
@@ -32,6 +32,7 @@ class Client(models.Model):
     _name = "client"
     _description = "Registro de Clientes."
 
+    sequence = fields.Integer(string='Sequência',  default=1)
     name = fields.Char(string='Nome do Cliente', required=True)
     client_type = fields.Selection(selection=[('pessoa-fisica', 'Pessoa Física'),
                                               ('pessoa-juridica', 'Pessoa Jurídica'),

--- a/registers/models/client.py
+++ b/registers/models/client.py
@@ -62,9 +62,10 @@ class Client(models.Model):
                                                 ('sergipe', 'SE'), ('tocantins', 'TO'),
                                                 ('distrito-federal', 'DF')],
                                                 string='Estado do Endereço',
-                                                required=True, defaul='rio-de-janeiro')
+                                                required=False, defaul='rio-de-janeiro')
     address_city = fields.Char(string='Cidade do Endereço', required=True)
     address_complement = fields.Char(string='Complemento do Endereço', required=False)
+    address_country = fields.Char(string='País do Endereço', required=False)
     cpf = fields.Char(string='CPF', required=False)
     rg = fields.Char(string='RG', required=False)
     cnpj = fields.Char(string='CNPJ', required=False)
@@ -91,8 +92,10 @@ class Client(models.Model):
         if self.pf_type:
             if self.pf_type == 'estrangeiro':
                 self.cpf = False
+                self.address_state = False
             elif self.pf_type == 'nacional':
                 self.foreign_doc = False
+                self.address_country = False
 
         vals = {
             'name': self.name,
@@ -235,6 +238,15 @@ class Client(models.Model):
                 if not (rec.cnpj).isnumeric():
                     raise ValidationError(_("O campo 'CNPJ' contém carácteres inválidos. "
                                                 "O campo deve conter apenas números."))
+
+    @api.constrains('address_country')
+    def _validate_address_countrt(self):
+        """Validates if 'address_country' has anything other than letters"""
+        for rec in self:
+            if rec.address_country:
+                if rec.address_country.isalpha() is False:
+                    raise ValidationError(_("O campo 'País do Endereço' aceita apenas "
+                                            "\nletras."))
 
     _sql_constraints = [
         ('cpf_client_unique', 'UNIQUE(cpf)', 'Já existe um \'Cliente\' com esse \'CPF\'.'),

--- a/registers/models/client.py
+++ b/registers/models/client.py
@@ -246,7 +246,7 @@ class Client(models.Model):
             if rec.address_country:
                 if rec.address_country.isalpha() is False:
                     raise ValidationError(_("O campo 'País do Endereço' aceita apenas "
-                                            "\nletras."))
+                                            "letras."))
 
     _sql_constraints = [
         ('cpf_client_unique', 'UNIQUE(cpf)', 'Já existe um \'Cliente\' com esse \'CPF\'.'),

--- a/registers/models/contract.py
+++ b/registers/models/contract.py
@@ -25,6 +25,7 @@ class Contract(models.Model):
     _inherit = ["mail.thread"]
     _rec_name = "display_name"
 
+    sequence = fields.Integer(string="Sequência", default=1)
     id_contract = fields.Char(string='Código', required=True)
     register_date = fields.Date(string='Data de Registro', default=_default_current_date)
     contract_date = fields.Date(string='Data do Contrato', required=True)

--- a/registers/models/cost_center.py
+++ b/registers/models/cost_center.py
@@ -11,6 +11,7 @@ class CostCenter(models.Model):
     _name = "cost_center"
     _description = "Registro de Centro de Custo."
 
+    sequence = fields.Integer(string="Sequência", default=1)
     id_cost_center = fields.Char(string='Código', required=True)
     name = fields.Char(string='Nome', required=True)
     about = fields.Text(string='Descrição', required=False)

--- a/registers/models/patrimony.py
+++ b/registers/models/patrimony.py
@@ -26,10 +26,9 @@ class Patrimony(models.Model):
     _inherit = ["mail.thread"]
     _rec_name = "display_name"
 
+    sequence = fields.Integer(string='Sequência',  default=1)
     id_patrimony = fields.Char(string='Código', required=True)
-
     fuel_type = fields.Char(string='Combustível', required=False)
-
     vehicle_maker = fields.Char(string='Marca', required=False)
     vehicle_model = fields.Char(string='Modelo', required=False)
 

--- a/registers/models/supplier.py
+++ b/registers/models/supplier.py
@@ -14,6 +14,7 @@ class Supplier(models.Model):
     _name = "supplier"
     _description = "Registro de Fornecedor."
 
+    sequence = fields.Integer(string='Sequência', default=1)
     supplier_area = fields.Char(string='Área de Fornecumento', required=False)
     name = fields.Char(string='Nome', required=True)
     cnpj = fields.Char(string='CNPJ', required=False)

--- a/registers/views/bill.xml
+++ b/registers/views/bill.xml
@@ -271,7 +271,7 @@
         <field name="name">bill.list</field>
         <field name="model">bill</field>
         <field name="arch" type="xml">
-            <list string="Despesas">
+            <list string="Despesas" default_order="register_date desc">
                 <field class="test" name="id_bill" />
                 <field class="test" name="value" />
                 <field class="test" name="validation_date" />

--- a/registers/views/client.xml
+++ b/registers/views/client.xml
@@ -26,9 +26,16 @@
                             </div>
 
                             <div class="subgroup">
-                                <div class="container_field">
+                                <div class="container_field" invisible="pf_type == 'estrangeiro'">
                                     <span>Estado:</span>
-                                    <field class="field" name="address_state" />
+                                    <field class="field" name="address_state"
+                                    required="pf_type != 'estrangeiro'" />
+                                </div>
+
+                                <div class="container_field" invisible="pf_type != 'estrangeiro'">
+                                    <span>País:</span>
+                                    <field class="field" name="address_country"
+                                    required="pf_type == 'estrangeiro'" />
                                 </div>
 
                                 <div class="container_field">

--- a/registers/views/client.xml
+++ b/registers/views/client.xml
@@ -170,6 +170,7 @@
         <field name="model">client</field>
         <field name="arch" type="xml">
             <list string="Clientes">
+                <field class="test" name="sequence" widget="handle" />
                 <field class="test" name="name" />
                 <field class="test" name="client_type" />
                 <field class="test" name="tel_one" />

--- a/registers/views/contract.xml
+++ b/registers/views/contract.xml
@@ -126,6 +126,7 @@
         <field name="model">contract</field>
         <field name="arch" type="xml">
             <list string="Contrato">
+                <field class="test" name="sequence" widget="handle" />
                 <field class="test" name="id_contract" />
                 <field class="test" name="external_client_id" />
                 <field class="test" name="status" />

--- a/registers/views/cost_center.xml
+++ b/registers/views/cost_center.xml
@@ -52,6 +52,7 @@
         <field name="model">cost_center</field>
         <field name="arch" type="xml">
             <list string="Centro de Custo">
+                <field class="test" name="sequence" widget="handle" />
                 <field class="test" name="id_cost_center"/>
                 <field class="test" name="name"/>
             </list>

--- a/registers/views/employee.xml
+++ b/registers/views/employee.xml
@@ -130,7 +130,7 @@
                 <field class="test" name="name" />
                 <field class="test" name="cpf" />
                 <field class="test" name="status" decoration-success="status == 'ativo'"
-                    decoration-danger="status == 'desligado'" />
+                    decoration-danger="status == 'inativo'" />
             </list>
         </field>
     </record>

--- a/registers/views/invoice.xml
+++ b/registers/views/invoice.xml
@@ -127,10 +127,9 @@
                                 </div>
 
                                 <div class="container_field">
-                                    <span>Dia de Recebimento:</span>
-                                    <field class="field" name="external_operation_id"
-                                        widget="selection"
-                                        readonly="1" />
+                                    <span>Descrição:</span>
+                                    <field class="field" name="description"
+                                        readonly="invoice_status != '0'" />
                                 </div>
 
                             </div>
@@ -143,9 +142,10 @@
                                 </div>
 
                                 <div class="container_field">
-                                    <span>Descrição:</span>
-                                    <field class="field" name="description"
-                                        readonly="invoice_status != '0'" />
+                                    <span>Dia de Recebimento:</span>
+                                    <field class="field" name="external_operation_id"
+                                        widget="selection"
+                                        readonly="1" />
                                 </div>
 
                             </div>

--- a/registers/views/invoice.xml
+++ b/registers/views/invoice.xml
@@ -213,7 +213,7 @@
         <field name="name">invoice.list</field>
         <field name="model">invoice</field>
         <field name="arch" type="xml">
-            <list string="Receitas">
+            <list string="Receitas" default_order="register_date desc">
                 <field class="test" name="id_invoice" />
                 <field class="test" name="value" />
                 <field class="test" name="invoice_status" decoration-info="invoice_status == '0'"

--- a/registers/views/operation.xml
+++ b/registers/views/operation.xml
@@ -98,7 +98,7 @@
         <field name="name">operation.list</field>
         <field name="model">operation</field>
         <field name="arch" type="xml">
-            <list string="Operação de Caixa">
+            <list string="Operação de Caixa" default_order="operation_date desc">
                 <field class="test" name="operation_status"/>
                 <field class="test" name="operation_date"/>
                 <field class="test" name="total_profit"

--- a/registers/views/patrimony.xml
+++ b/registers/views/patrimony.xml
@@ -200,6 +200,9 @@
                 <field class="test" name="vehicle_maker" />
                 <field class="test" name="vehicle_model" />
                 <field class="test" name="value" />
+                <field class="test" name="status"
+                decoration-success="status == 'ativo'"
+                decoration-danger="status == 'inativo'"/>
             </list>
         </field>
     </record>

--- a/registers/views/patrimony.xml
+++ b/registers/views/patrimony.xml
@@ -195,6 +195,7 @@
         <field name="model">patrimony</field>
         <field name="arch" type="xml">
             <list string="Patrimônio">
+                <field class="test" name="sequence" widget="handle" />
                 <field class="test" name="id_patrimony" />
                 <field class="test" name="vehicle_maker" />
                 <field class="test" name="vehicle_model" />

--- a/registers/views/supplier.xml
+++ b/registers/views/supplier.xml
@@ -100,6 +100,7 @@
         <field name="model">supplier</field>
         <field name="arch" type="xml">
             <list string="Fornecedores">
+                <field class="test" name="sequence" widget="handle" />
                 <field class="test" name="name" />
                 <field class="test" name="supplier_area" />
             </list>


### PR DESCRIPTION
Added:
- Validation for incompatible 'patrimony' and 'contract' on bill
- Option for 'country' when 'client' is international
- Visual QOL features for 'patrimony', 'client', 'contract' and 'cost-center' on list view
- Ordering of 'invoice', 'bill' and 'operation' based on creation date